### PR TITLE
fix s3/kms/dynamodb permissions & use tfvars in buildspec

### DIFF
--- a/modules/pipeline/main.tf
+++ b/modules/pipeline/main.tf
@@ -21,6 +21,13 @@ resource "aws_iam_role" "codepipeline_role" {
   ]
 }
 EOF
+
+  tags {
+    business-unit = "${var.tags["business-unit"]}"
+    application   = "${var.tags["application"]}"
+    is-production = "${var.tags["is-production"]}"
+    owner         = "${var.tags["owner"]}"
+  }
 }
 
 resource "aws_iam_role_policy" "codepipeline_policy" {
@@ -149,6 +156,13 @@ resource "aws_iam_role" "codebuild_role" {
   ]
 }
 EOF
+
+  tags {
+    business-unit = "${var.tags["business-unit"]}"
+    application   = "${var.tags["application"]}"
+    is-production = "${var.tags["is-production"]}"
+    owner         = "${var.tags["owner"]}"
+  }
 }
 
 resource "aws_iam_role_policy" "codebuild_policy" {
@@ -190,7 +204,32 @@ resource "aws_iam_role_policy" "codebuild_policy" {
     {
       "Effect": "Allow",
       "Action": "s3:*Object",
-      "Resource": "${aws_s3_bucket.codepipeline_bucket.arn}/tfplan"
+      "Resource": [
+        "${aws_s3_bucket.codepipeline_bucket.arn}/tfplan",
+        "arn:aws:s3:::${var.tf_state_bucket}/iam"
+      ]
+    },
+    {
+      "Effect": "Allow",
+      "Action": "s3:ListBucket",
+      "Resource": "arn:aws:s3:::${var.tf_state_bucket}"
+    },
+    {
+      "Effect": "Allow",
+      "Action": [
+        "kms:Decrypt",
+        "kms:Encrypt"
+      ],
+      "Resource": "${var.tf_state_kms_key_arn}"
+    },
+    {
+      "Effect": "Allow",
+      "Action": [
+        "dynamodb:PutItem",
+        "dynamodb:GetItem",
+        "dynamodb:DeleteItem"
+      ],
+      "Resource": "${var.tf_lock_table_arn}"
     }
   ]
 } 
@@ -229,8 +268,11 @@ resource "aws_codebuild_project" "build_project_tf_plan" {
     buildspec = "pipeline/buildspec-plan.yml"
   }
 
-  tags = {
-    "environment-name" = "landing"
+  tags {
+    business-unit = "${var.tags["business-unit"]}"
+    application   = "${var.tags["application"]}"
+    is-production = "${var.tags["is-production"]}"
+    owner         = "${var.tags["owner"]}"
   }
 }
 
@@ -266,7 +308,10 @@ resource "aws_codebuild_project" "build_project_tf_apply" {
     buildspec = "pipeline/buildspec-apply.yml"
   }
 
-  tags = {
-    "environment-name" = "landing"
+  tags {
+    business-unit = "${var.tags["business-unit"]}"
+    application   = "${var.tags["application"]}"
+    is-production = "${var.tags["is-production"]}"
+    owner         = "${var.tags["owner"]}"
   }
 }

--- a/modules/pipeline/variables.tf
+++ b/modules/pipeline/variables.tf
@@ -15,3 +15,26 @@ variable "codebuild_compute_type" {
 variable "codebuild_image" {
   default = "aws/codebuild/standard:1.0"
 }
+
+variable "tf_state_bucket" {
+  default = "tf-state-analytical-platform-landing"
+}
+
+variable "tf_state_kms_key_arn" {
+  default = "arn:aws:kms:eu-west-1:335823981503:key/925a5b6c-7df1-49a0-a3cc-471e8524637d"
+}
+
+variable "tf_lock_table_arn" {
+  default = "arn:aws:dynamodb:*:*:table/tf-state-lock"
+}
+
+variable "tags" {
+  type = "map"
+
+  default = {
+    business-unit = "Platforms"
+    application   = "analytical-platform"
+    is-production = true
+    owner         = "analytical-platform:analytics-platform-tech@digital.justice.gov.uk"
+  }
+}

--- a/pipeline/buildspec-apply.yml
+++ b/pipeline/buildspec-apply.yml
@@ -18,7 +18,7 @@ phases:
       - cd $CODEBUILD_SRC_DIR
       - terraform init -input=false
       - aws s3 cp s3://$PLAN_BUCKET/tfplan tfplan
-      - terraform apply -input=false tfplan
+      - terraform apply -var-file=vars/landing.tfvars -input=false tfplan
 
   post_build:
     commands:

--- a/pipeline/buildspec-plan.yml
+++ b/pipeline/buildspec-plan.yml
@@ -17,7 +17,7 @@ phases:
     commands:
       - cd $CODEBUILD_SRC_DIR
       - terraform init -input=false
-      - terraform plan -out=tfplan -input=false
+      - terraform plan -var-file=vars/landing.tfvars -out=tfplan -input=false
       - aws s3 cp tfplan s3://$PLAN_BUCKET/tfplan
 
   post_build:


### PR DESCRIPTION
__Permissions__
* Allow CodeBuild to access S3 bucket/KMS key to access iam tf state file
* Allow CodeBuild to access TF lock database (dynamodb)

__Terraform__
* Pass landing.tfvars to terraform commands in buildspec (not picked up automatically due to being in subdirectory)

__Tags__
* Tag resources in line with the [MOJ Technical Guidance](https://ministryofjustice.github.io/technical-guidance/standards/documenting-infrastructure-owners/#documenting-owners-of-infrastructure)