### PR TITLE
allow codebuild to assume cross account roles

### DIFF
--- a/modules/pipeline/main.tf
+++ b/modules/pipeline/main.tf
@@ -230,6 +230,11 @@ resource "aws_iam_role_policy" "codebuild_policy" {
         "dynamodb:DeleteItem"
       ],
       "Resource": "${var.tf_lock_table_arn}"
+    },
+    {
+      "Effect": "Allow",
+      "Action": "sts:AssumeRole",
+      "Resource": "arn:aws:iam::*:role/landing-iam-role"
     }
   ]
 } 


### PR DESCRIPTION
__Assume Cross Account Roles__
* Allow CodeBuild to assume `landing-iam-role` in data/dev/prod accounts
* `landing-iam-role` allows management of IAM within those accounts