### PR TITLE
Restricted Admin IAM OIDC

### DIFF
--- a/policy-restricted-admin.tf
+++ b/policy-restricted-admin.tf
@@ -64,8 +64,10 @@ data "aws_iam_policy_document" "restricted_admin" {
       "iam:CreateAccessKey",
       "iam:CreateGroup",
       "iam:CreateInstanceProfile",
+      "iam:CreateOpenIDConnectProvider",
       "iam:CreatePolicy",
       "iam:CreateRole",
+      "iam:CreateSAMLProvider",
       "iam:CreateUser",
       "iam:CreateVirtualMFADevice",
       "iam:DeactivateMFADevice",
@@ -76,6 +78,8 @@ data "aws_iam_policy_document" "restricted_admin" {
       "iam:DeletePolicy",
       "iam:DeleteRole",
       "iam:DeleteRolePolicy",
+      "iam:DeleteSAMLProvider",
+      "iam:DeleteOpenIDConnectProvider",
       "iam:DeleteSSHPublicKey",
       "iam:DeleteUser",
       "iam:DeleteUserPolicy",
@@ -97,6 +101,7 @@ data "aws_iam_policy_document" "restricted_admin" {
       "iam:TagRole",
       "iam:UntagRole",
       "iam:UpdateAccessKey",
+      "iam:UpdateOpenIDConnectProviderThumbprint",
       "iam:UploadSSHPublicKey",
     ]
 


### PR DESCRIPTION
Add required permissions to allow a resticted admin to manage oidc and
saml providers in `IAM`.