### PR TITLE
Add Suspended Users Group (controversial)

### DIFF
--- a/assume-landing.tf
+++ b/assume-landing.tf
@@ -73,3 +73,21 @@ module "add_read_only_role_in_landing" {
   role_principal_identifiers = ["arn:aws:iam::${var.landing_account_id}:root"]
   role_principal_type        = "AWS"
 }
+
+##### SUSPENDED USERS #####
+## Create suspended users group for inactive users
+
+module "add_suspended_users_group_in_landing" {
+  source = "modules/assume"
+
+  assumed_role_name = "nil"
+
+  assume_role_in_account_id = ["nil"]
+  landing_account_id        = "${var.landing_account_id}"
+  group_name                = "${var.suspended_users_name}"
+  group_effect              = "Deny"
+
+  users = [
+    "${aws_iam_user.suspended.name}",
+  ]
+}

--- a/modules/assume/main.tf
+++ b/modules/assume/main.tf
@@ -1,12 +1,12 @@
 locals {
-  roles = "${join(",\n",formatlist("arn:aws:iam::%s:role/%s", var.assume_role_in_account_id, var.assumed_role_name))}"
+  roles = "${join(",\n", formatlist("arn:aws:iam::%s:role/%s", var.assume_role_in_account_id, var.assumed_role_name))}"
 }
 
 data "aws_iam_policy_document" "policy" {
   statement {
-    effect    = "Allow"
-    actions   = ["sts:AssumeRole"]
-    resources = ["${local.roles}"]
+    effect    = "${var.group_effect}"
+    actions   = ["${var.group_effect == "Allow" ? "sts:AssumeRole" : "*"}"]
+    resources = ["${var.group_effect == "Allow" ? local.roles : "*"}"]
   }
 }
 

--- a/modules/assume/variables.tf
+++ b/modules/assume/variables.tf
@@ -20,3 +20,8 @@ variable "users" {
   description = "A list of users"
   type        = "list"
 }
+
+variable "group_effect" {
+  description = "The explicit Allow or Deny on the group's policy"
+  default     = "Allow"
+}

--- a/users.tf
+++ b/users.tf
@@ -24,3 +24,8 @@ resource "aws_iam_user" "olivier" {
   name          = "olivier.butterbach@digital.justice.gov.uk"
   force_destroy = true
 }
+
+resource "aws_iam_user" "suspended" {
+  name          = "suspended.test@digital.justice.gov.uk"
+  force_destroy = true
+}

--- a/variables.tf
+++ b/variables.tf
@@ -65,3 +65,9 @@ variable "terraform_aws_security_name" {
 variable "landing_iam_role" {
   default = "landing-iam-role"
 }
+
+## Suspended Users
+
+variable "suspended_users_name" {
+  default = "suspended_users"
+}


### PR DESCRIPTION
Relates to [PR](https://github.com/ministryofjustice/analytical-platform-iam/pull/64)

After a period of inactivity user accounts should be effectively
disabled or prevented from assuming any roles.

Some of the principles with this are redundant as user accounts have no
associated permissions and are implicily permission-less without group
membership. Just removing a user from all groups achieves the desired
effect.

Refactor Assume Module:
- Allow variable __effect__ on IAM group's policy
- Set the __actions__ and __resources__ of IAM group's policy based on policy __effect__

Create Suspended Users Group
- Invoke Assume module with __nil__ place holders for assume logic