### PR TITLE
Add ability to Simulate Policies

### DIFF
--- a/policy-read-only.tf
+++ b/policy-read-only.tf
@@ -17,6 +17,7 @@ data "aws_iam_policy_document" "read_only" {
       "events:List*",
       "iam:Get*",
       "iam:List*",
+      "iam:SimulatePrincipalPolicy",
       "logs:Describe*",
       "logs:Get*",
       "route53:Get*",

--- a/policy-restricted-admin.tf
+++ b/policy-restricted-admin.tf
@@ -103,6 +103,7 @@ data "aws_iam_policy_document" "restricted_admin" {
       "iam:PutUserPolicy",
       "iam:RemoveRoleFromInstanceProfile",
       "iam:RemoveUserFromGroup",
+      "iam:SimulatePrincipalPolicy",
       "iam:TagRole",
       "iam:UntagRole",
       "iam:UpdateAccessKey",


### PR DESCRIPTION
`iam:SimulatePrincipalPolicy` is required to check actions granularly
with spec tests and the policy simulator.