### PR TITLE
Fix to allow user to set their own MFA

### DIFF
--- a/modules/assume/policy-manage-own-creds.tf
+++ b/modules/assume/policy-manage-own-creds.tf
@@ -102,7 +102,7 @@ data "aws_iam_policy_document" "manage_own_creds" {
     ]
 
     resources = [
-      "arn:aws:iam::*:user/$${aws:username}",
+      "arn:aws:iam::*:mfa/$${aws:username}",
     ]
   }
 


### PR DESCRIPTION
Change according to what the error message in the console says it should be. And it matches the reference example: https://docs.aws.amazon.com/IAM/latest/UserGuide/reference_policies_examples_aws_my-sec-creds-self-manage-mfa-only.html'