### PR TITLE
Added `iam:DeletePolicyVersion` permission to restricted admin

### DIFF
--- a/policy-restricted-admin.tf
+++ b/policy-restricted-admin.tf
@@ -87,6 +87,7 @@ data "aws_iam_policy_document" "restricted_admin" {
       "iam:DeleteRolePolicy",
       "iam:DeleteSAMLProvider",
       "iam:DeleteOpenIDConnectProvider",
+      "iam:DeletePolicyVersion",
       "iam:DeleteSSHPublicKey",
       "iam:DeleteUser",
       "iam:DeleteUserPolicy",


### PR DESCRIPTION
Tried to update the CP IAM role in the console (made the change in terraform
but wanted to avoid to do a `terraform apply`) and got this error while
trying up update it. Restricted admin role was already supposed to have
 ermission to edit roles anyway so this is fixing that.

Ticket: https://trello.com/c/zqsliluS