### PR TITLE
Add Quicksight admin role and user for gareth davies

### DIFF
--- a/assume-data.tf
+++ b/assume-data.tf
@@ -21,7 +21,7 @@ module "assume_restricted_admin_in_data" {
     "${aws_iam_user.aldo.name}",
     "${aws_iam_user.david.name}",
     "${aws_iam_user.dhiraj.name}",
-    "${aws_iam_user.andrew.name}"
+    "${aws_iam_user.andrew.name}",
   ]
 }
 
@@ -88,7 +88,7 @@ module "assume_read_s3_only_in_data" {
     "${aws_iam_user.calum.name}",
     "${aws_iam_user.sam.name}",
     "${aws_iam_user.dhiraj.name}",
-    "${aws_iam_user.andrew.name}"
+    "${aws_iam_user.andrew.name}",
   ]
 }
 
@@ -127,7 +127,7 @@ module "assume_data_admin_in_data" {
     "${aws_iam_user.david.name}",
     "${aws_iam_user.robin.name}",
     "${aws_iam_user.dhiraj.name}",
-    "${aws_iam_user.andrew.name}"
+    "${aws_iam_user.andrew.name}",
   ]
 }
 
@@ -179,7 +179,7 @@ module "add_data_engineers_group" {
     "${aws_iam_user.calum.name}",
     "${aws_iam_user.anthony.name}",
     "${aws_iam_user.robin.name}",
-    "${aws_iam_user.sam.name}"
+    "${aws_iam_user.sam.name}",
   ]
 }
 
@@ -217,7 +217,7 @@ module "add_hmcts_data_engineers_group" {
     "${aws_iam_user.calum.name}",
     "${aws_iam_user.anthony.name}",
     "${aws_iam_user.robin.name}",
-    "${aws_iam_user.sam.name}"
+    "${aws_iam_user.sam.name}",
   ]
 }
 
@@ -254,7 +254,7 @@ module "add_probation_data_engineers_group" {
     "${aws_iam_user.calum.name}",
     "${aws_iam_user.anthony.name}",
     "${aws_iam_user.robin.name}",
-    "${aws_iam_user.sam.name}"
+    "${aws_iam_user.sam.name}",
   ]
 }
 
@@ -291,7 +291,7 @@ module "add_prison_data_engineers_group" {
     "${aws_iam_user.calum.name}",
     "${aws_iam_user.anthony.name}",
     "${aws_iam_user.robin.name}",
-    "${aws_iam_user.sam.name}"
+    "${aws_iam_user.sam.name}",
   ]
 }
 
@@ -328,7 +328,7 @@ module "add_corporate_data_engineers_group" {
     "${aws_iam_user.calum.name}",
     "${aws_iam_user.anthony.name}",
     "${aws_iam_user.robin.name}",
-    "${aws_iam_user.sam.name}"
+    "${aws_iam_user.sam.name}",
   ]
 }
 
@@ -382,10 +382,9 @@ module "add_billing_viewer_group" {
     "${aws_iam_user.david.name}",
     "${aws_iam_user.aldo.name}",
     "${aws_iam_user.dhiraj.name}",
-    "${aws_iam_user.andrew.name}"
+    "${aws_iam_user.andrew.name}",
   ]
 }
-
 
 ##### Quicksight Admin #####
 ## Quicksight Admin Group

--- a/assume-data.tf
+++ b/assume-data.tf
@@ -385,3 +385,37 @@ module "add_billing_viewer_group" {
     "${aws_iam_user.andrew.name}"
   ]
 }
+
+
+##### Quicksight Admin #####
+## Quicksight Admin Group
+
+module "assume_quicksight_admin_in_data" {
+  source = "modules/assume"
+
+  assumed_role_name = "${var.quicksight_admin_name}-${local.data}"
+
+  assume_role_in_account_id = [
+    "${var.ap_accounts["data"]}",
+  ]
+
+  landing_account_id = "${var.landing_account_id}"
+  group_name         = "${var.quicksight_admin_name}-${local.data}"
+
+  users = [
+    "${aws_iam_user.gareth.name}",
+  ]
+}
+
+## Create quicksight admin role in data account
+module "add_quicksight_admin_role_in_data" {
+  source = "modules/role"
+
+  providers = {
+    aws = "aws.data"
+  }
+
+  role_name          = "${var.quicksight_admin_name}-${local.data}"
+  landing_account_id = "${var.landing_account_id}"
+  role_policy        = "${data.aws_iam_policy_document.quicksight_admin.json}"
+}

--- a/assume-dev.tf
+++ b/assume-dev.tf
@@ -21,7 +21,7 @@ module "assume_restricted_admin_in_dev" {
     "${aws_iam_user.aldo.name}",
     "${aws_iam_user.david.name}",
     "${aws_iam_user.dhiraj.name}",
-    "${aws_iam_user.andrew.name}"
+    "${aws_iam_user.andrew.name}",
   ]
 }
 
@@ -57,7 +57,7 @@ module "assume_read_only_in_dev" {
     "${aws_iam_user.aldo.name}",
     "${aws_iam_user.david.name}",
     "${aws_iam_user.dhiraj.name}",
-    "${aws_iam_user.andrew.name}"
+    "${aws_iam_user.andrew.name}",
   ]
 }
 

--- a/assume-landing.tf
+++ b/assume-landing.tf
@@ -22,7 +22,7 @@ module "assume_restricted_admin_in_landing" {
     "${aws_iam_user.sam.name}",
     "${aws_iam_user.david.name}",
     "${aws_iam_user.dhiraj.name}",
-    "${aws_iam_user.andrew.name}"
+    "${aws_iam_user.andrew.name}",
   ]
 }
 
@@ -59,7 +59,7 @@ module "assume_read_only_in_landing" {
     "${aws_iam_user.aldo.name}",
     "${aws_iam_user.david.name}",
     "${aws_iam_user.dhiraj.name}",
-    "${aws_iam_user.andrew.name}"
+    "${aws_iam_user.andrew.name}",
   ]
 }
 

--- a/assume-prod.tf
+++ b/assume-prod.tf
@@ -21,7 +21,7 @@ module "assume_restricted_admin_in_prod" {
     "${aws_iam_user.aldo.name}",
     "${aws_iam_user.david.name}",
     "${aws_iam_user.dhiraj.name}",
-    "${aws_iam_user.andrew.name}"
+    "${aws_iam_user.andrew.name}",
   ]
 }
 
@@ -57,7 +57,7 @@ module "assume_read_only_in_prod" {
     "${aws_iam_user.aldo.name}",
     "${aws_iam_user.david.name}",
     "${aws_iam_user.dhiraj.name}",
-    "${aws_iam_user.andrew.name}"
+    "${aws_iam_user.andrew.name}",
   ]
 }
 

--- a/policy-quicksight-admin.tf
+++ b/policy-quicksight-admin.tf
@@ -1,0 +1,12 @@
+data "aws_iam_policy_document" "quicksight_admin" {
+  statement {
+    sid    = "QuicksightAll"
+    effect = "Allow"
+
+    actions = [
+      "quicksight:*",
+    ]
+
+    resources = ["*"]
+  }
+}

--- a/users.tf
+++ b/users.tf
@@ -59,3 +59,8 @@ resource "aws_iam_user" "andrew" {
   name          = "andrew.lightfoot@digital.justice.gov.uk"
   force_destroy = true
 }
+
+resource "aws_iam_user" "gareth" {
+  name          = "gareth.davies@digital.justice.gov.uk"
+  force_destroy = true
+}

--- a/variables.tf
+++ b/variables.tf
@@ -76,3 +76,9 @@ variable "probation_data_engineers_name" {
 variable "corporate_data_engineers_name" {
   default = "data-engineers-corporate"
 }
+
+## Quicksight Admin
+
+variable "quicksight_admin_name" {
+  default = "quicksight-admin"
+}


### PR DESCRIPTION
Gareth Davies is going to perform an evaluation of Quicksight in the data account.

This change does the following
- Adds a quicksight admin IAM role with full access to Quicksight in the data account
- Add an IAM user for Gareth Davies in the landing account
- Gives access for Gareth to assume the quicksight admin role in the data account
- Also fix terraform fmt validation errors reported by CircleCI pipeline

We may restrict the Quicksight permissions that we grant at a later time, but in order for Gareth to be able to conduct his evaluation we have given the role full access to Quicksight.