### PR TITLE
Allow Prison data engineer role access to s3 bucket locations for Pat…

### DIFF
--- a/policy-readwrite-de-prisons.tf
+++ b/policy-readwrite-de-prisons.tf
@@ -22,6 +22,9 @@ data "aws_iam_policy_document" "prison_data_engineer" {
       "arn:aws:s3:::mojap-raw-hist/hmpps/prison*",
       "arn:aws:s3:::mojap-raw/hmpps/prison*",
       "arn:aws:s3:::mojap-raw-hist/hmpps-migration-backup/*",
+      "arn:aws:s3:::mojap-land/hmpps/pathfinder*",
+      "arn:aws:s3:::mojap-raw-hist/hmpps/pathfinder*",
+      "arn:aws:s3:::mojap-raw/hmpps/pathfinder*",
     ]
   }
 }

--- a/policy-readwrite-de-prisons.tf
+++ b/policy-readwrite-de-prisons.tf
@@ -16,15 +16,15 @@ data "aws_iam_policy_document" "prison_data_engineer" {
 
     resources = [
       "arn:aws:s3:::mojap-land/hmpps/nomis*",
-      "arn:aws:s3:::mojap-raw-hist/hmpps/nomis*",
-      "arn:aws:s3:::mojap-raw/hmpps/nomis*",
-      "arn:aws:s3:::mojap-land/hmpps/prison*",
-      "arn:aws:s3:::mojap-raw-hist/hmpps/prison*",
-      "arn:aws:s3:::mojap-raw/hmpps/prison*",
-      "arn:aws:s3:::mojap-raw-hist/hmpps-migration-backup/*",
       "arn:aws:s3:::mojap-land/hmpps/pathfinder*",
-      "arn:aws:s3:::mojap-raw-hist/hmpps/pathfinder*",
+      "arn:aws:s3:::mojap-land/hmpps/prison*",
+      "arn:aws:s3:::mojap-raw/hmpps/nomis*",
       "arn:aws:s3:::mojap-raw/hmpps/pathfinder*",
+      "arn:aws:s3:::mojap-raw/hmpps/prison*",
+      "arn:aws:s3:::mojap-raw-hist/hmpps/nomis*",
+      "arn:aws:s3:::mojap-raw-hist/hmpps/pathfinder*",
+      "arn:aws:s3:::mojap-raw-hist/hmpps/prison*",
+      "arn:aws:s3:::mojap-raw-hist/hmpps-migration-backup/*",
     ]
   }
 }


### PR DESCRIPTION
In order that the members of the Data Engineering team can review the Pathfinder data from HMPPS we need to give them access to the location of the data in the landing, raw and history S3 buckets.

Allow data-engineers-prisons IAM role read and write access to the following bucket locations.

- s3://mojap-land/hmpps/pathfinder*
- s3://mojap-raw/hmpps/pathfinder*
- s3://mojap-raw-hist/hmpps/pathfinder*