### PR TITLE
Update restricted admin policy to include Resource Access Manager

### DIFF
--- a/policy-restricted-admin.tf
+++ b/policy-restricted-admin.tf
@@ -34,6 +34,7 @@ data "aws_iam_policy_document" "restricted_admin" {
       "kms:*",
       "lambda:*",
       "logs:*",
+      "ram:*",
       "rds:*",
       "resource-groups:ListGroups*",
       "route53:*",


### PR DESCRIPTION
This PR adds the AWS Resource Access Manager service to the restricted admin policy.