### PR TITLE
➰ ➰ loop de loop ➰ ➰

### DIFF
--- a/team-de-all.tf
+++ b/team-de-all.tf
@@ -17,9 +17,8 @@ locals {
     }
 
     "data-first-data-engineer" = {
-      user_names       = module.corporate_data_engineering_team.user_names
-      user_arns        = module.corporate_data_engineering_team.user_arns
-      policy_documents = {}
+      user_names = module.corporate_data_engineering_team.user_names
+      user_arns  = module.corporate_data_engineering_team.user_arns
     }
 
     "prison-data-engineer" = {
@@ -48,9 +47,17 @@ module "data_engineer" {
   destination_role_name    = each.key
   user_names               = each.value["user_names"]
   user_arns                = each.value["user_arns"]
-  aws_iam_policy_documents = each.value["policy_documents"]
+  aws_iam_policy_documents = contains(keys(each.value), "policy_documents") ? each.value["policy_documents"] : {}
+  managed_policies         = contains(keys(each.value), "managed_policies") ? each.value["managed_policies"] : local.default_managed_policies
 
-  managed_policies = [
+  providers = {
+    aws.source      = aws.landing
+    aws.destination = aws.data
+  }
+}
+
+locals {
+  default_managed_policies = [
     "arn:aws:iam::aws:policy/AmazonAthenaFullAccess",
     "arn:aws:iam::aws:policy/AWSGlueConsoleFullAccess",
     "arn:aws:iam::aws:policy/AWSLakeFormationDataAdmin",
@@ -62,13 +69,4 @@ module "data_engineer" {
     "arn:aws:iam::aws:policy/CloudWatchSyntheticsReadOnlyAccess",
     "arn:aws:iam::aws:policy/AWSCloudTrailReadOnlyAccess",
   ]
-
-  providers = {
-    aws.source      = aws.landing
-    aws.destination = aws.data
-  }
-}
-
-output "role_name" {
-  value    = module.data_engineer[each.key].destination_role.name
 }

--- a/team-de-all.tf
+++ b/team-de-all.tf
@@ -1,0 +1,74 @@
+locals {
+  teams = {
+    "courts-data-engineer" = {
+      user_names = module.courts_data_engineering_team.user_names
+      user_arns  = module.courts_data_engineering_team.user_arns
+      policy_documents = {
+        "courts_data_engineer" = data.aws_iam_policy_document.courts_data_engineer,
+      }
+    }
+
+    "corporate-data-engineer" = {
+      user_names = module.corporate_data_engineering_team.user_names
+      user_arns  = module.corporate_data_engineering_team.user_arns
+      policy_documents = {
+        "corporate_data_engineer" = data.aws_iam_policy_document.corporate_data_engineer,
+      }
+    }
+
+    "data-first-data-engineer" = {
+      user_names       = module.corporate_data_engineering_team.user_names
+      user_arns        = module.corporate_data_engineering_team.user_arns
+      policy_documents = {}
+    }
+
+    "prison-data-engineer" = {
+      user_names = module.prison_data_engineering_team.user_names
+      user_arns  = module.prison_data_engineering_team.user_arns
+      policy_documents = {
+        "prison_data_engineer" = data.aws_iam_policy_document.prison_data_engineer,
+      }
+    }
+
+    "probation-data-engineer" = {
+      user_names = module.probation_data_engineering_team.user_names
+      user_arns  = module.probation_data_engineering_team.user_arns
+      policy_documents = {
+        "probation_data_engineer" = data.aws_iam_policy_document.probation_data_engineer,
+      }
+    }
+  }
+}
+
+module "data_engineer" {
+  for_each = local.teams
+  source   = "./modules/assume_role"
+  tags     = local.tags
+
+  destination_role_name    = each.key
+  user_names               = each.value["user_names"]
+  user_arns                = each.value["user_arns"]
+  aws_iam_policy_documents = each.value["policy_documents"]
+
+  managed_policies = [
+    "arn:aws:iam::aws:policy/AmazonAthenaFullAccess",
+    "arn:aws:iam::aws:policy/AWSGlueConsoleFullAccess",
+    "arn:aws:iam::aws:policy/AWSLakeFormationDataAdmin",
+    "arn:aws:iam::aws:policy/AWSSupportAccess",
+    "arn:aws:iam::aws:policy/AWSCloudTrailReadOnlyAccess",
+    "arn:aws:iam::aws:policy/CloudWatchReadOnlyAccess",
+    "arn:aws:iam::aws:policy/CloudWatchLogsReadOnlyAccess",
+    "arn:aws:iam::aws:policy/CloudWatchEventsReadOnlyAccess",
+    "arn:aws:iam::aws:policy/CloudWatchSyntheticsReadOnlyAccess",
+    "arn:aws:iam::aws:policy/AWSCloudTrailReadOnlyAccess",
+  ]
+
+  providers = {
+    aws.source      = aws.landing
+    aws.destination = aws.data
+  }
+}
+
+output "role_name" {
+  value    = module.data_engineer[each.key].destination_role.name
+}

--- a/team-de-corporate.tf
+++ b/team-de-corporate.tf
@@ -30,9 +30,7 @@ module "corporate_data_engineer" {
   }
 }
 
-output "corporate_data_engineer_role_name" {
-  value = module.corporate_data_engineer.destination_role.name
-}
+
 
 data "aws_iam_policy_document" "corporate_data_engineer" {
   statement {

--- a/versions.tf
+++ b/versions.tf
@@ -1,4 +1,9 @@
 
 terraform {
-  required_version = ">= 0.12"
+  required_version = ">= 0.13"
+  required_providers {
+    aws = {
+      source = "hashicorp/aws"
+    }
+  }
 }


### PR DESCRIPTION
This demonstrates passing in a block of blocks to a generic(ish) module
We now provide defaults to managed_policies and policy documents, so
they don't need to be specified.

This has the benefit of separating out the data from the logic/module
call, reducing the lines of code to do the same operation for all the
data engineers.

This can only be done for one account at a time as the provider block
cannot be dynamic.